### PR TITLE
Ajout des fichiers .meta par unity pour permettre l'import du package depuis Github

### DIFF
--- a/Assets.meta
+++ b/Assets.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c47ce65b93b043042b128e0d772387d6
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor.meta
+++ b/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: eac51ea9a30f9734c86bf24f6cd542ef
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime.meta
+++ b/Runtime.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 05a040a4635cb7e4ab2b5346acdc8d1d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/package.json.meta
+++ b/package.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e8192cc6ae586a247a9e531271b9c292
+PackageManifestImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Contexte initial
Le package de ce sdk a été fourni sans fichiers .meta, ce qui signifie qu'il ne pouvait être importé que via l'option `Add from disk` dans Unity.

## Objectif
Avec cette mise à jour, les fichiers .meta ont été ajoutés après l'importation et le lancement du package dans Unity. Désormais, on espère pouvoir importer ce package directement depuis le dépôt Git avec l'option `Add from Git URL`.